### PR TITLE
Drop out of update loop when no tasks

### DIFF
--- a/corrcli/commands/cli.py
+++ b/corrcli/commands/cli.py
@@ -8,7 +8,8 @@ from ..tools import get_config_dir
 DEFAULT_CONFIG_FILE = 'config.ini'
 DEFAULT_DAEMON_DIR = 'daemons'
 DEFAULT_TASK_DIR = 'tasks'
-DEFAULT_REFRESH_RATE = 5.0
+DEFAULT_WRITE_REFRESH_RATE = 5.0
+DEFAULT_WATCH_REFRESH_RATE = 0.1
 
 @click.group()
 @click.version_option(get_version())

--- a/corrcli/commands/config.py
+++ b/corrcli/commands/config.py
@@ -14,19 +14,24 @@ def config():
 @config.command('set')
 @click.option('--email', default=None, help="Add email address.", type=str)
 @click.option('--author', default=None, help="Add author's name.", type=str)
-@click.option('--refresh-rate',
+@click.option('--watch-refresh-rate',
               default=None,
               help="The refresh rate for watching tasks.",
               type=float)
+@click.option('--write-refresh-rate',
+              default=None,
+              help="The refresh rate for writing tasks.",
+              type=float)
 @click.pass_context
-def set_config(ctx, email, author, refresh_rate):
+def set_config(ctx, email, author, watch_refresh_rate, write_refresh_rate):
     """Write data to the 'config.ini' file.
     """
     ini_file = os.path.join(ctx.parent.parent.params['config_dir'], DEFAULT_CONFIG_FILE)
 
     entries = [('default', 'email', email),
                ('default', 'author', author),
-               ('tasks', 'refresh_rate', refresh_rate)]
+               ('tasks', 'write_refresh_rate', write_refresh_rate),
+               ('tasks', 'watch_refresh_rate', watch_refresh_rate)]
 
     for section, key, value in entries:
         if value:

--- a/corrcli/task_manager.py
+++ b/corrcli/task_manager.py
@@ -94,8 +94,10 @@ def task_manager_callback(daemon_id, config_dir, logger=None):
     """
     task_manager_dict = dict()
     config_data = parse_config(config_dir)
-    watch_refresh_rate = float(config_data.get('tasks_watch_refresh_rate', DEFAULT_WATCH_REFRESH_RATE))
-    write_refresh_rate = float(config_data.get('tasks_write_refresh_rate', DEFAULT_WRITE_REFRESH_RATE))
+    watch_refresh_rate = float(config_data.get('tasks_watch_refresh_rate',
+                                               DEFAULT_WATCH_REFRESH_RATE))
+    write_refresh_rate = float(config_data.get('tasks_write_refresh_rate',
+                                               DEFAULT_WRITE_REFRESH_RATE))
     while True:
         tstart = time.time()
         pids = get_pids_for_identifier(daemon_id)

--- a/corrcli/task_manager.py
+++ b/corrcli/task_manager.py
@@ -9,7 +9,7 @@ import psutil
 
 from .watchers.process_watcher import ProcessWatcher
 from .watchers.platform_watcher import PlatformWatcher
-from .commands.cli import DEFAULT_REFRESH_RATE
+from .commands.cli import DEFAULT_WRITE_REFRESH_RATE, DEFAULT_WATCH_REFRESH_RATE
 from .commands.config import parse_config
 from .stores.file_store import FileStore
 
@@ -94,13 +94,18 @@ def task_manager_callback(daemon_id, config_dir, logger=None):
     """
     task_manager_dict = dict()
     config_data = parse_config(config_dir)
-    refresh_rate = float(config_data.get('tasks_refresh_rate', DEFAULT_REFRESH_RATE))
+    watch_refresh_rate = float(config_data.get('tasks_watch_refresh_rate', DEFAULT_WATCH_REFRESH_RATE))
+    write_refresh_rate = float(config_data.get('tasks_write_refresh_rate', DEFAULT_WRITE_REFRESH_RATE))
     while True:
         tstart = time.time()
         pids = get_pids_for_identifier(daemon_id)
         task_manager_dict = update_task_manager_dict(pids, task_manager_dict, config_dir, logger)
-        while (time.time() - tstart) < refresh_rate:
-            update_task_manager_data(task_manager_dict)
+        if len(task_manager_dict) > 0:
+            while (time.time() - tstart) < write_refresh_rate:
+                update_task_manager_data(task_manager_dict)
+                time.sleep(watch_refresh_rate)
+        else:
+            time.sleep(write_refresh_rate)
         task_manager_dict = write_task_manager_data(task_manager_dict, logger)
 
 

--- a/corrcli/tests/test_task_manager.py
+++ b/corrcli/tests/test_task_manager.py
@@ -7,7 +7,7 @@ from time import sleep
 from click.testing import CliRunner
 
 from corrcli.corr_daemon import CoRRDaemon
-from corrcli.commands.cli import DEFAULT_REFRESH_RATE
+from corrcli.commands.cli import DEFAULT_WRITE_REFRESH_RATE
 from corrcli.stores.file_store import FileStore
 from corrcli.tools import start_daemon
 
@@ -22,7 +22,7 @@ def configure(config_dir, refresh_rate):
                  'set',
                  '--email=test@test.com',
                  '--author="Test Person"',
-                 '--refresh-rate={0}'.format(refresh_rate)]
+                 '--write-refresh-rate={0}'.format(refresh_rate)]
     Popen(arguments).wait()
     sleep(3)
 
@@ -58,16 +58,16 @@ while True:
 def test_task_manager():
     """Test that tasks can be captured.
     """
-    refresh_rate = 1
+    write_refresh_rate = 1
     runner = CliRunner()
     with runner.isolated_filesystem() as config_path:
-        configure(config_path, refresh_rate)
+        configure(config_path, write_refresh_rate)
         start_daemon(config_path)
         daemon_df = CoRRDaemon.list(config_path)
         daemon_id = daemon_df.daemon_id[0]
         try:
             process = start_process(daemon_id, config_path)
-            sleep(refresh_rate + 1)
+            sleep(write_refresh_rate + 1)
             tasks = FileStore.read_all(config_path)
         except: # pragma: no cover
             process.kill()
@@ -75,7 +75,7 @@ def test_task_manager():
         process.kill()
         assert len(tasks) == 1
         assert tasks[0]['status'] != 'finished'
-        sleep(refresh_rate + 1)
+        sleep(write_refresh_rate + 1)
         tasks = FileStore.read_all(config_path)
         assert len(tasks) == 1
         assert tasks[0]['status'] == 'zombie'
@@ -92,7 +92,7 @@ def test_noconfig():
         daemon_id = daemon_df.daemon_id[0]
         try:
             process = start_process(daemon_id, config_path)
-            sleep(DEFAULT_REFRESH_RATE * 2)
+            sleep(DEFAULT_WRITE_REFRESH_RATE * 2)
             tasks = FileStore.read_all(config_path)
         except: # pragma: no cover
             process.kill()


### PR DESCRIPTION
Address #22

Drop out of the task update loop when no tasks are available. This
stops corrcli from using all the resources for 1 cpu. Also include a
second refresh rate to reduced CPU usage. This will need to be tuned
when corrcli has more process inspection tools.
